### PR TITLE
Fix connection of variable resolvers inside a SBVPCase

### DIFF
--- a/packages/Sandblocks-VisualPrimitives/SBStDeclarationForVPBinding.class.st
+++ b/packages/Sandblocks-VisualPrimitives/SBStDeclarationForVPBinding.class.st
@@ -1,0 +1,76 @@
+Class {
+	#name : #SBStDeclarationForVPBinding,
+	#superclass : #SBStDeclarationBehavior,
+	#category : #'Sandblocks-VisualPrimitives'
+}
+
+{ #category : #'as yet unclassified' }
+SBStDeclarationForVPBinding class >> checkCastFor: aBlock parent: aMorph [
+
+	^ aMorph isBlockBindings
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> asSuggestionItem [
+
+	^ SBSuggestionItem selector: self contents label: 'block var'
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> guessedClass [
+
+	^ self block containingArtefact typeFor: self block
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> inputCommandClass [
+
+	^ SBStBindingRenameCommand
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> isBlockBinding [
+
+	^ true
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> isMethodLocal [
+
+	^ true
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> prefix [
+
+	^ ':'
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> printBlockOn: aStream [
+
+	aStream nextPutAll: 'block declaration '; nextPutAll: self contents
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> scope [
+
+	^ {self block root parentSandblock}
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> symbolsFor: aColorPolicy [
+
+	^ aColorPolicy symbolsForBlockDeclaration: self block
+]
+
+{ #category : #accessing }
+SBStDeclarationForVPBinding >> valid [
+	" check that this name does not already exist in a parent scope "
+
+	^ (self block containingBlock parentSandblock
+		binding: self contents
+		for: self block
+		class: (self block containingArtefact ifNotNil: #relatedClass)
+		ifPresent: [:binding | binding isMethodLocal ifTrue: [binding] ifFalse: [nil]]) isNil
+]

--- a/packages/Sandblocks-VisualPrimitives/SBTreeDecorator.class.st
+++ b/packages/Sandblocks-VisualPrimitives/SBTreeDecorator.class.st
@@ -300,7 +300,7 @@ SBTreeDecorator >> secondWalk: aValue [
 	self x: self x + aValue.
 	self morph
 		fullBounds;
-		center: self x @ self depth * 100.
+		center: self x @ self depth * 40.
 	self children do: [:child | child secondWalk: aValue + self mod]
 ]
 

--- a/packages/Sandblocks-VisualPrimitives/SBVPBindingPattern.class.st
+++ b/packages/Sandblocks-VisualPrimitives/SBVPBindingPattern.class.st
@@ -127,6 +127,12 @@ SBVPBindingPattern >> addToWorld: aWorld [
 ]
 
 { #category : #'as yet unclassified' }
+SBVPBindingPattern >> bindingBlock [
+
+	^ self innerLabel
+]
+
+{ #category : #'as yet unclassified' }
 SBVPBindingPattern >> bindingFor: aVisualPrimitive [
 
 	^ self getCurrentPrimitive: aVisualPrimitive
@@ -145,7 +151,14 @@ SBVPBindingPattern >> bindingIndex: anObject [
 	bindingIndex := anObject isSandblock
 		ifTrue: [anObject evaluate]
 		ifFalse: [anObject].
-	label := SBTextBubble new contents: bindingIndex asString.
+	label := SBStName new
+		autoCast: [:name :owner | | case |
+			case := self root parentSandblock.
+			((case isKindOf: SBVPCase) and: [name hasOwner: case input])
+				ifTrue: [name behaviorClass: SBStDeclarationForVPBinding]
+				ifFalse: [name behaviorClass: SBStBinding]];
+		behavior: SBStDeclarationForBlock new;
+		contents: bindingIndex asString.
 	label when: #contentsChanged send: #bindingIndexChanged to: self.
 	self innerLabel: label.
 	self labelDict removeKey: #innerLabel
@@ -238,7 +251,7 @@ SBVPBindingPattern >> childrenInCurrentMatch [
 SBVPBindingPattern >> collectBindingsInto: aCollection [
 
 	super collectBindingsInto: aCollection.
-	aCollection add: self bindingIndex
+	aCollection add: self bindingBlock
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-VisualPrimitives/SBVPCase.class.st
+++ b/packages/Sandblocks-VisualPrimitives/SBVPCase.class.st
@@ -128,6 +128,16 @@ SBVPCase >> addToggleButtonFor: aSymbol [
 ]
 
 { #category : #'as yet unclassified' }
+SBVPCase >> binding: aString for: block class: aClass ifPresent: aBlock [
+
+	| bindingsSet |
+	bindingsSet := Set new.
+	self inputRoot collectBindingsInto: bindingsSet.
+	bindingsSet detect: [:b | b contents = aString] ifFound: [:b | ^ aBlock value: b].
+	^ super binding: aString for: block class: aClass ifPresent: aBlock
+]
+
+{ #category : #'as yet unclassified' }
 SBVPCase >> buildImplicitChildrenMatchingPattern [
 
 	self input ifNotNil: #removeImplicitChildren.
@@ -400,6 +410,12 @@ SBVPCase >> input: anSBBlock output: anotherSBBlock [
 	self buildImplicitChildrenMatchingPattern
 	";
 		colorDifferences"
+]
+
+{ #category : #'as yet unclassified' }
+SBVPCase >> inputRoot [
+
+	^ self input connections first
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-VisualPrimitives/SBVPConstraintPattern.class.st
+++ b/packages/Sandblocks-VisualPrimitives/SBVPConstraintPattern.class.st
@@ -55,20 +55,6 @@ SBVPConstraintPattern >> artefactSaved: aMethodBlock [
 	constraint := self constraintBlock evaluate
 ]
 
-{ #category : #'as yet unclassified' }
-SBVPConstraintPattern >> binding: aString for: block class: aClass ifPresent: aBlock [
-
-	| bindingsSet |
-	bindingsSet := Set new.
-	self root collectBindingsInto: bindingsSet.
-	(bindingsSet includes: aString asSymbol) ifTrue: [ | variable |
-		variable := (SBVPConstraintVariable poolDeclaration: aString) binding: aString asSymbol -> SBVisualPrimitive new.
-		(block isKindOf: SBVPConstraintVariable) ifFalse: [block replaceBy: variable].
-		"avoid replacing same block multiple times"
-		^ aBlock value: variable].
-	^ super binding: aString for: block class: aClass ifPresent: aBlock
-]
-
 { #category : #accessing }
 SBVPConstraintPattern >> constraint [
 

--- a/packages/Sandblocks-VisualPrimitives/SBVPExecuter.class.st
+++ b/packages/Sandblocks-VisualPrimitives/SBVPExecuter.class.st
@@ -61,20 +61,22 @@ SBVPExecuter class >> exampleBuildHeap: aTree [
 		label: 'example'.
 	^ (SBVPCase
 		input: (SBVPGroupPattern patterns: {
-			SBVPBindingPattern bindingIndex: #a connections: {
-				SBVPEllipsisPattern bindingIndex: #b.
+			SBVPBindingPattern bindingIndex: #a labelDict: {} connections: {
+				SBVPEllipsisPattern bindingIndex: #b labelDict: {}.
 				SBVPBindingPattern
 					bindingIndex: #boi
-					connections: {SBVPEllipsisPattern bindingIndex: #e}.
-				SBVPEllipsisPattern bindingIndex: #d}.
+					labelDict: {}
+					connections: {SBVPEllipsisPattern bindingIndex: #e labelDict: {}}.
+				SBVPEllipsisPattern bindingIndex: #d labelDict: {}}.
 			SBVPConstraintPattern constraint: [:bindings | (bindings at: #a) label asInteger < (bindings at: #boi) label asInteger]})
 		output: (SBVPGroupPattern patterns: {
-			SBVPBindingPattern bindingIndex: #boi connections: {
-				SBVPEllipsisPattern bindingIndex: #b.
+			SBVPBindingPattern bindingIndex: #boi labelDict: {} connections: {
+				SBVPEllipsisPattern bindingIndex: #b labelDict: {}.
 				SBVPBindingPattern
 					bindingIndex: #a
-					connections: {SBVPEllipsisPattern bindingIndex: #e}.
-				SBVPEllipsisPattern bindingIndex: #d}})
+					labelDict: {}
+					connections: {SBVPEllipsisPattern bindingIndex: #e labelDict: {}}.
+				SBVPEllipsisPattern bindingIndex: #d labelDict: {}}})
 		strategy: (Dictionary new
 			add: #explicitRootMatching -> false;
 			add: #explicitChildrenMatching -> false;


### PR DESCRIPTION
NOTE: requires newest version of Sandblocks-Core

* introduces a new SBDeclarationForVPBinding that is more or less a direct copy of SBDeclarationForBlockBinding, except that its `scope` not only goes to its parent but all the way up to the VPCase
* bindingFor: is now moved from Constraint up to the Case; it also answers the declarations (i.e. the blocks in the input) rather than new instances of pool variables
* UNRELATED CHANGE: decreases the distance of tree nodes from 100 to 40

Potentially breaking change: I had to change the SBTextBubble that used to be in the binding pattern to be a SBStName. Please verify that this doesn't break things elsewhere.